### PR TITLE
Fix Mana Cost for Restoration Shaman

### DIFF
--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -16,13 +16,13 @@ const spells = spellIndexableList({
     id: 77130,
     name: 'Purify Spirit',
     icon: 'ability_shaman_cleansespirit',
-    manaCost: 650,
+    manaCost: 3250,
   },
   EARTHBIND_TOTEM: {
     id: 2484,
     name: 'Earthbind Totem',
     icon: 'spell_nature_strengthofearthtotem02',
-    manaCost: 250,
+    manaCost: 1250,
   },
   RESONANCE_TOTEM_HASTE: {
     id: 262417,
@@ -73,19 +73,19 @@ const spells = spellIndexableList({
     id: 192106,
     name: 'Lightning Shield',
     icon: 'spell_nature_lightningshield',
-    manaCost: 150,
+    manaCost: 750,
   },
   LIGHTNING_SHIELD_ELEMENTAL: {
     id: 344174, // Appears to be the spellID used when lightning shield does damage as Elemental Spec
     name: 'Lightning Shield',
     icon: 'spell_nature_lightningshield',
-    manaCost: 150,
+    manaCost: 750,
   },
   PRIMAL_STRIKE: {
     id: 73899,
     name: 'Primal Strike',
     icon: 'spell_shaman_primalstrike',
-    manaCost: 940,
+    manaCost: 4700,
   },
   ANCESTRAL_PROTECTION_BUFF: {
     id: 207495,
@@ -164,7 +164,7 @@ const spells = spellIndexableList({
     id: 188196,
     name: 'Lightning Bolt',
     icon: 'spell_nature_lightning',
-    manaCost: 100,
+    manaCost: 500,
   },
   LIGHTNING_BOLT_INSTANT: {
     id: 214815,
@@ -477,13 +477,13 @@ const spells = spellIndexableList({
     id: 2825,
     name: 'Bloodlust',
     icon: 'spell_nature_bloodlust',
-    manaCost: 2150,
+    manaCost: 1000,
   },
   HEROISM: {
     id: 32182,
     name: 'Heroism',
     icon: 'ability_shaman_heroism',
-    manaCost: 2150,
+    manaCost: 1000,
   },
   REINCARNATION: {
     id: 21169,
@@ -585,7 +585,7 @@ const spells = spellIndexableList({
     id: 8004,
     name: 'Healing Surge',
     icon: 'spell_nature_healingway',
-    manaCost: 2400, // enh/ele cost is higher
+    manaCost: 12000, // enh/ele cost is higher
   },
   TIDAL_WAVES_BUFF: {
     id: 53390,

--- a/src/common/TALENTS/shaman.ts
+++ b/src/common/TALENTS/shaman.ts
@@ -550,7 +550,7 @@ const talents = createTalentList({
     icon: 'spell_shaman_focusedstrikes',
     maxRanks: 1,
     entryIds: [101967],
-    manaCost: 10000,
+    manaCost: 8000,
   },
   GUARDIANS_CUDGEL_TALENT: {
     id: 381819,
@@ -587,7 +587,7 @@ const talents = createTalentList({
     icon: 'inv_spear_04',
     maxRanks: 1,
     entryIds: [101900],
-    manaCost: 4500,
+    manaCost: 4300,
   },
   HEALING_STREAM_TOTEM_SHARED_TALENT: {
     id: 5394,
@@ -922,7 +922,7 @@ const talents = createTalentList({
     icon: 'spell_nature_purge',
     maxRanks: 1,
     entryIds: [101968],
-    manaCost: 5000,
+    manaCost: 4000,
   },
   RAGING_MAELSTROM_TALENT: {
     id: 384143,


### PR DESCRIPTION
### Description

This is an update for Mana Cost values of Abilities and Talents for Restoration Shaman.

### Testing

Compare the values with in-game ones, with Dragonflight 10.1 version.